### PR TITLE
Update checkout action

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
 #---------- 4. Installation of the tSQLt framework
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install tSQLt with SQL auth on AdventureWorks2017
         uses: lowlydba/tsqlt-installer@v1


### PR DESCRIPTION
Remove the warning `Node.js 12 actions are deprecated` for issue #6  